### PR TITLE
added goreleaser and builds for mcp-example-crd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: goreleaser
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - .goreleaser.yaml
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+    
+      - uses: actions/setup-go@v5
+        with:
+          go-version: v1.22.10
+    
+      - name: Delete non-semver tags
+        run: 'git tag -d $(git tag -l | grep -v "^v")'
+      
+      - name: Run GoReleaser on tag
+        if: github.event_name != 'pull_request'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --timeout 60m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Run GoReleaser on pull request
+        if: github.event_name == 'pull_request'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --timeout 60m --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: binaries
+          path: dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /_build/
+/dist/
 /_tools/
 /vendor/
 /.kcp.e2e/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+builds:
+  - id: "mcp-example-crd"
+    main: examples/crd/cmd/main.go
+    binary: mcp-example-crd
+    ldflags:
+      - "-s -w"
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+
+archives:
+  - id: mcp-example-crd
+    builds:
+      - mcp-example-crd
+
+release:
+  draft: true
+  mode: keep-existing

--- a/examples/crd/Makefile
+++ b/examples/crd/Makefile
@@ -93,7 +93,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -o bin/mcp-example-crd cmd/main.go
 
 .PHONY: run
 run:  ## Run a controller from your host.
@@ -250,4 +250,4 @@ kcp-tools: $(KCP_APIGEN_GEN)
 .PHONY: kcp-tools
 
 kcp-generate:
-	$(TOOLS_DIR)/apigen --input-dir ./config/crd/bases --output-dir ./config/kcp    
+	$(TOOLS_DIR)/apigen --input-dir ./config/crd/bases --output-dir ./config/kcp


### PR DESCRIPTION
This PR adds goreleaser and related GH actions. The configmap example doesn't seem to build?